### PR TITLE
Update addon.xml

### DIFF
--- a/plugin.video.itv/addon.xml
+++ b/plugin.video.itv/addon.xml
@@ -13,7 +13,7 @@
     <platform>all</platform>
     <summary>TV from ITV Hub</summary>
     <description>This add-on enables the playing of Live and Catchup TV from ITV Hub (UK only)</description>
-    <disclaimer lang="en">This add-on is a front end to the ITV Hub website. It is not an official ITV product. A UK TV Licence is required to watch the live, catch-up, or on-demand TV content.</disclaimer>
+    <disclaimer lang="en">This add-on is a front end to the ITV Hub website. It is not an official ITV product. A UK TV Licence is required to watch the live TV content.</disclaimer>
     <assets>
       <icon>icon.png</icon>
   </assets>


### PR DESCRIPTION
TV Licence is not needed to watch catch up, only live (broadcast) TV.

FWIW this addon no longer gives me the option of live TV so perhaps that text needs updating also, or at least qualifying when it will provide it